### PR TITLE
Simplified triplecast logic in Fire IV and other fixed

### DIFF
--- a/XIVSlothCombo/Combos/PvE/BLM.cs
+++ b/XIVSlothCombo/Combos/PvE/BLM.cs
@@ -497,6 +497,7 @@ internal class BLM
 
                 if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) &&
                     PolyglotStacks > Config.BLM_ST_UsePolyglot_HoldCharges &&
+                     HasEffect(Buffs.Firestarter) && 
                     GetBuffRemainingTime(Buffs.Firestarter) > 3)
                     return LevelChecked(Xenoglossy)
                         ? Xenoglossy

--- a/XIVSlothCombo/Combos/PvE/BLM.cs
+++ b/XIVSlothCombo/Combos/PvE/BLM.cs
@@ -424,11 +424,9 @@ internal class BLM
                             (thunderDebuffST is null || thunderDebuffST.RemainingTime < 3))
                             return OriginalHook(Thunder);
 
-                        if (HasPolyglotStacks(Gauge) && gcdsInTimer >= 1 &&
-                            (ActionReady(All.Swiftcast) ||
-                             (ActionReady(Triplecast) &&
-                              GetBuffStacks(Buffs.Triplecast) == 0 &&
-                              GetRemainingCharges(Triplecast) == GetMaxCharges(Triplecast))))
+                        if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) &&
+                            PolyglotStacks > Config.BLM_ST_UsePolyglot_HoldCharges && 
+                            GetRemainingCharges(Triplecast) == GetMaxCharges(Triplecast))
                             return Xenoglossy.LevelChecked()
                                 ? Xenoglossy
                                 : Foul;

--- a/XIVSlothCombo/Combos/PvE/BLM.cs
+++ b/XIVSlothCombo/Combos/PvE/BLM.cs
@@ -426,7 +426,11 @@ internal class BLM
 
                         if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) &&
                             PolyglotStacks > Config.BLM_ST_UsePolyglot_HoldCharges && 
-                            GetRemainingCharges(Triplecast) == GetMaxCharges(Triplecast))
+                            IsEnabled(CustomComboPreset.BLM_ST_Triplecast) &&
+                            canWeave && ActionReady(Triplecast) &&
+                            GetBuffStacks(Buffs.Triplecast) == 0 &&
+                            (GetRemainingCharges(Triplecast) > Config.BLM_ST_Triplecast_HoldCharges ||
+                             TriplecastChargetime <= Config.BLM_ST_Triplecast_ChargeTime))
                             return Xenoglossy.LevelChecked()
                                 ? Xenoglossy
                                 : Foul;
@@ -492,7 +496,8 @@ internal class BLM
                     return Paradox;
 
                 if (IsEnabled(CustomComboPreset.BLM_ST_UsePolyglot) &&
-                    PolyglotStacks > Config.BLM_ST_UsePolyglot_HoldCharges)
+                    PolyglotStacks > Config.BLM_ST_UsePolyglot_HoldCharges &&
+                    GetBuffRemainingTime(Buffs.Firestarter) > 3)
                     return LevelChecked(Xenoglossy)
                         ? Xenoglossy
                         : Foul;


### PR DESCRIPTION
- Accidently left a check for swiftcast even though it wasn't being used, causing xeno to be used even when it wasn't correct.
- Added a check when using Xeno during umbral ice and you have a firestarter proc active. This is to prevent from xeno being spammed and firestarter expiring